### PR TITLE
Remove media query breakpoints from Tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,22 +11,6 @@ module.exports = {
         background: "var(--background)",
         foreground: "var(--foreground)",
       },
-    },
-    screens: {
-      'sm': '0px',
-      // => @media (min-width: 640px) { ... }
-
-      'md': '768px',
-      // => @media (min-width: 768px) { ... }
-
-      'lg': '1024px',
-      // => @media (min-width: 1024px) { ... }
-
-      'xl': '1280px',
-      // => @media (min-width: 1280px) { ... }
-
-      '2xl': '1536px',
-      // => @media (min-width: 1536px) { ... }
     }
   },
   plugins: [],


### PR DESCRIPTION
The media query breakpoints (sm, md, lg, xl, 2xl) defined in the tailwind.config.js file have been removed. They are no longer needed as the application's responsive design is managed differently. The removal of these properties simplifies the configuration and improves maintainability.