### PR TITLE
fixed error handling in getPublicVoucherUses

### DIFF
--- a/utils/ServerActions/voucher.ts
+++ b/utils/ServerActions/voucher.ts
@@ -349,8 +349,11 @@ const getPublicVoucherUses = async (voucherId: number) => {
     console.log('used', data[0].used_per_user);
     return data[0].used_per_user;
   } catch (error: any) {
-    console.error(`Failed to fetch public vouchers uses: ${error.message}`);
-
+    if (error.message === `Cannot read properties of undefined (reading 'used_per_user')`) // this is part of the logic, we check whether this voucher has been used at all
+      console.log(`Voucher ${voucherId} has not been used yet`);
+    else {
+      console.error(`Failed to fetch public vouchers uses: ${error.message}`);
+    }
   }
 }
 
@@ -367,7 +370,7 @@ export const fetchAllVouchers = async () => {
 
     await Promise.all(publicVouchers.map(async (pv) => {
       try {
-        const used=(await getPublicVoucherUses(pv.id))||0
+        const used = (await getPublicVoucherUses(pv.id)) || 0 // if voucher has not been used, the we show 0
         console.log(used);
 
         pv.used = used ? used : 0;


### PR DESCRIPTION
Since catch block is part of logic, it should not be logged as error.