### PR TITLE
fixed bug with voucher flip that occured in safari

### DIFF
--- a/components/QrCodes/VoucherQR.tsx
+++ b/components/QrCodes/VoucherQR.tsx
@@ -48,11 +48,13 @@ const VoucherQR = ({
     }
   }, [used]);
 
-
   return (
     <div className='voucher-background'>
       <div className="m-8 w-96">
-        <ReactCardFlip isFlipped={flip} flipDirection="horizontal">
+        <ReactCardFlip isFlipped={flip} flipDirection="horizontal" cardStyles={{
+          front: { zIndex: 'unset', transformStyle: 'initial' },
+          back: { zIndex: 'unset', transformStyle: 'initial' }
+        }}>
           {/* front side */}
           <div className="voucher" >
             <div className='close-button' onClick={() => setShowQrCode(false)}>


### PR DESCRIPTION
Fixed the bug that mirror-flipped the voucher on Safari. Now it shows the redeem message as it is supposed to.